### PR TITLE
use `ellmer::chat_anthropic()` over `ellmer::chat_claude()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/simonpcouch/chores/issues
 Imports: 
     cli (>= 3.6.3),
     glue (>= 1.8.0),
-    ellmer,
+    ellmer (>= 0.2.0),
     miniUI (>= 0.1.1.1),
     rlang (>= 1.1.4),
     rstudioapi (>= 0.17.1),

--- a/R/helper-class.R
+++ b/R/helper-class.R
@@ -51,7 +51,7 @@ fetch_chores_chat <- function(.chores_chat = getOption(".chores_chat")) {
         "!" = "chores requires configuring an ellmer Chat with the
         {cli::col_blue('.chores_chat')} option.",
         "i" = "Set e.g.
-        {.code {cli::col_green('options(.chores_chat = ellmer::chat_claude())')}}
+        {.code {cli::col_green('options(.chores_chat = ellmer::chat_anthropic())')}}
         in your {.file ~/.Rprofile} and restart R.",
         "i" = "See \"Choosing a model\" in
         {.code vignette(\"chores\", package = \"chores\")} to learn more."

--- a/R/init-helper.R
+++ b/R/init-helper.R
@@ -11,8 +11,8 @@
 #' of `r glue::glue_collapse(paste0("[", glue::double_quote(default_chores), "]", "[", default_chores, "_helper", "]"), ", ", last = " or ")`,
 #' though custom helpers can be added with [prompt_new()].
 #' @param .chores_chat An ellmer Chat, e.g.
-#' `function() ellmer::chat_claude()`. Defaults to the option by the same name,
-#' so e.g. set `options(.chores_chat = ellmer::chat_claude())` in your
+#' `function() ellmer::chat_anthropic()`. Defaults to the option by the same name,
+#' so e.g. set `options(.chores_chat = ellmer::chat_anthropic())` in your
 #' `.Rprofile` to configure chores with ellmer every time you start a new R session.
 #'
 #' @returns
@@ -22,7 +22,7 @@
 #' # requires an API key and sets options
 #' \dontrun{
 #' # to create a chat with claude:
-#' .init_helper(.chores_chat = ellmer::chat_claude())
+#' .init_helper(.chores_chat = ellmer::chat_anthropic())
 #'
 #' # or with OpenAI's 4o-mini:
 #' .init_helper(.chores_chat = ellmer::chat_openai(model = "gpt-4o-mini"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,7 @@ You can install the developmental version with:
 pak::pak("simonpcouch/chores")
 ```
 
-**2)** Then, you need to configure chores with an [ellmer](https://ellmer.tidyverse.org/) model. chores uses ellmer under the hood, so any model that you can chat with through ellmer is also supported by chores. To configure chores with ellmer, set the option `.chores_chat` to any ellmer Chat. For example, to use Claude, you'd write `options(.chores_chat = ellmer::chat_claude())`, possibly in your `.Rprofile` so that chores is ready to go every time you start R. To learn more, see the [Getting started with chores](https://simonpcouch.github.io/chores/articles/chores.html) vignette.
+**2)** Then, you need to configure chores with an [ellmer](https://ellmer.tidyverse.org/) model. chores uses ellmer under the hood, so any model that you can chat with through ellmer is also supported by chores. To configure chores with ellmer, set the option `.chores_chat` to any ellmer Chat. For example, to use Claude, you'd write `options(.chores_chat = ellmer::chat_anthropic())`, possibly in your `.Rprofile` so that chores is ready to go every time you start R. To learn more, see the [Getting started with chores](https://simonpcouch.github.io/chores/articles/chores.html) vignette.
 
 **3)** Chore helpers are interfaced with the via the chores addin. For easiest access, we recommend registering the chores addin to a keyboard shortcut.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ pak::pak("simonpcouch/chores")
 the hood, so any model that you can chat with through ellmer is also
 supported by chores. To configure chores with ellmer, set the option
 `.chores_chat` to any ellmer Chat. For example, to use Claude, you’d
-write `options(.chores_chat = ellmer::chat_claude())`, possibly in your
-`.Rprofile` so that chores is ready to go every time you start R. To
-learn more, see the [Getting started with
+write `options(.chores_chat = ellmer::chat_anthropic())`, possibly in
+your `.Rprofile` so that chores is ready to go every time you start R.
+To learn more, see the [Getting started with
 chores](https://simonpcouch.github.io/chores/articles/chores.html)
 vignette.
 

--- a/man/dot-init_helper.Rd
+++ b/man/dot-init_helper.Rd
@@ -12,8 +12,8 @@ of \link[=cli_helper]{"cli"}, \link[=testthat_helper]{"testthat"} or \link[=roxy
 though custom helpers can be added with \code{\link[=prompt_new]{prompt_new()}}.}
 
 \item{.chores_chat}{An ellmer Chat, e.g.
-\code{function() ellmer::chat_claude()}. Defaults to the option by the same name,
-so e.g. set \code{options(.chores_chat = ellmer::chat_claude())} in your
+\code{function() ellmer::chat_anthropic()}. Defaults to the option by the same name,
+so e.g. set \code{options(.chores_chat = ellmer::chat_anthropic())} in your
 \code{.Rprofile} to configure chores with ellmer every time you start a new R session.}
 }
 \value{
@@ -31,7 +31,7 @@ with \code{\link[=prompt_new]{prompt_new()}}.
 # requires an API key and sets options
 \dontrun{
 # to create a chat with claude:
-.init_helper(.chores_chat = ellmer::chat_claude())
+.init_helper(.chores_chat = ellmer::chat_anthropic())
 
 # or with OpenAI's 4o-mini:
 .init_helper(.chores_chat = ellmer::chat_openai(model = "gpt-4o-mini"))

--- a/tests/testthat/test-helper-add-remove.R
+++ b/tests/testthat/test-helper-add-remove.R
@@ -1,7 +1,7 @@
 test_that("helper addition and removal works", {
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   boop_prompt <- "just reply with beep bop boop regardless of input"
   .helper_add("boopery", boop_prompt)

--- a/tests/testthat/test-helper-class.R
+++ b/tests/testthat/test-helper-class.R
@@ -1,7 +1,7 @@
 test_that("can find the previous helper", {
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   cli_helper <- .init_helper("cli")
   expect_no_error(response <- cli_helper$chat("stop(\"Error message here\")"))
@@ -10,7 +10,7 @@ test_that("can find the previous helper", {
 test_that("chores_chat effectively integrates system prompt", {
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   cli_helper <- .init_helper("cli")
   response <- cli_helper$chat("stop(\"Error message here\")")

--- a/tests/testthat/test-helper-init.R
+++ b/tests/testthat/test-helper-init.R
@@ -1,7 +1,7 @@
 test_that("initializing a helper", {
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   expect_snapshot(.init_helper("cli"))
   expect_snapshot(.init_helper("testthat"))
@@ -10,7 +10,7 @@ test_that("initializing a helper", {
 test_that("can use other models", {
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   # respects other argument values
   expect_snapshot(.init_helper(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,7 +2,7 @@ test_that(".helper_last is up to date with most recent helper", {
   skip_if(identical(Sys.getenv("ANTHROPIC_API_KEY"), ""))
   skip_if(identical(Sys.getenv("OPENAI_API_KEY"), ""))
   skip_if_not_installed("withr")
-  withr::local_options(.chores_chat = ellmer::chat_claude())
+  withr::local_options(.chores_chat = ellmer::chat_anthropic())
 
   .init_helper("cli")
   expect_snapshot(env_get(chores_env(), ".helper_last"))

--- a/vignettes/chores.Rmd
+++ b/vignettes/chores.Rmd
@@ -22,11 +22,11 @@ The chores package ships with a number of pre-engineered "chore helpers." A chor
 
 The chores addin supports any model supported by [ellmer](https://ellmer.tidyverse.org/). When choosing a model for use with chores, you'll want to the use the most performant model possible that satisfies your privacy needs; chores automatically passes along your selected code to your chosen model, so it's especially important to consider data privacy when using LLMs with chores.
 
-chores uses the `.chores_chat` option to configure which model powers the addin. `.chores_chat` should be set to an ellmer Chat object. For example, to use Anthropic's Claude, you might write `options(.chores_chat = ellmer::chat_claude())`. Paste that code in your `.Rprofile` via `usethis::edit_r_profile()` to always use the same model every time you start an R session.
+chores uses the `.chores_chat` option to configure which model powers the addin. `.chores_chat` should be set to an ellmer Chat object. For example, to use Anthropic's Claude, you might write `options(.chores_chat = ellmer::chat_anthropic())`. Paste that code in your `.Rprofile` via `usethis::edit_r_profile()` to always use the same model every time you start an R session.
 
 If you're using ellmer inside a organization, you'll be limited to what your IT department allows, which is likely to be one provided by a big cloud provider, e.g. `chat_azure()`, `chat_bedrock()`, `chat_databricks()`, or `chat_snowflake()`. If you're using ellmer for your own exploration, you'll have a lot more freedom, so we have a few recommendations to help you get started:
 
-- As of early 2025, Anthropic's **Claude Sonnet 3.5** is a very powerful model for code assistance and is the model I've used while developing the package. If you want to use Claude, you'll need to register an API key at `https://console.anthropic.com/` to the environment variable `ANTHROPIC_API_KEY` and then set `options(.chores_chat = ellmer::chat_claude())`. 
+- As of early 2025, Anthropic's **Claude Sonnet 3.5** is a very powerful model for code assistance and is the model I've used while developing the package. If you want to use Claude, you'll need to register an API key at `https://console.anthropic.com/` to the environment variable `ANTHROPIC_API_KEY` and then set `options(.chores_chat = ellmer::chat_anthropic())`. 
 
 * Regarding OpenAI's models, `chat_openai()` defaults to **GPT-4o**, but you can use `model = "gpt-4o-mini"` for a cheaper, lower-quality model; to use an OpenAI model, you'll need to set the options `options(.chores_chat = ellmer::chat_openai(model = "gpt-4o"))` and register your OpenAI API key with the `OPENAI_API_KEY` environment variable.
 


### PR DESCRIPTION
Thanks for this package!

I was getting a warning message:

```
`chat_claude()` was deprecated in ellmer 0.2.0.
ℹ Please use `chat_anthropic()` instead.
```

I figured you might appreciate a little update to remove this - this does mean the package depends on ellmer 0.2.0

Of course no worries if you'd rather not take this PR :)

Have a great day!